### PR TITLE
import __future__... and small clarification in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ A Python implementation of [RAISR](http://ieeexplore.ieee.org/document/7744595/)
 
 ### Prerequisites
 
+You need Python 3.x, older versions don't work out-of-the-box.
+
 You can install most of the following packages using [pip](https://pypi.python.org/pypi/pip).
+
+It is also important to have a 64 bit version of Python 3.x
 
 * [OpenCV-Python](https://pypi.python.org/pypi/opencv-python)
 * [NumPy](http://www.numpy.org/)

--- a/test.py
+++ b/test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import cv2
 import numpy as np
 import os

--- a/train.py
+++ b/train.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import cv2
 import numpy as np
 import os


### PR DESCRIPTION
I have learned very quickly that Python 2.x versions throw print errors. To fix that, I added ```from __future__ import print_function``` to at least eliminate those. Also, it seemed to be important to run a 64bit version of Python when dealing with bigger pictures. 

While this may sound like common sense, people still have version 2.7, running in 32 bit. So just by clarifying that it's recommended to run Python 3.x and use a 64bit version in the README helps.