### PR TITLE
Fix testing when scaling factor != 2

### DIFF
--- a/test.py
+++ b/test.py
@@ -62,8 +62,8 @@ for image in imagelist:
     heightgridLR = np.linspace(0,heightLR-1,heightLR)
     widthgridLR = np.linspace(0,widthLR-1,widthLR)
     bilinearinterp = interpolate.interp2d(widthgridLR, heightgridLR, grayorigin, kind='linear')
-    heightgridHR = np.linspace(0,heightLR-0.5,heightLR*2)
-    widthgridHR = np.linspace(0,widthLR-0.5,widthLR*2)
+    heightgridHR = np.linspace(0,heightLR-0.5,heightLR*R)
+    widthgridHR = np.linspace(0,widthLR-0.5,widthLR*R)
     upscaledLR = bilinearinterp(widthgridHR, heightgridHR)
     # Calculate predictHR pixels
     heightHR, widthHR = upscaledLR.shape


### PR DESCRIPTION
When R != 2, running test.py results in an error:

```py
Traceback (most recent call last):
  File "test.py", line 91, in <module>
    predictHR[row-margin,col-margin] = patch.dot(h[angle,strength,coherence,pixeltype])
IndexError: index 4 is out of bounds for axis 3 with size 4
```

This PR fixes that behavior!